### PR TITLE
fixes invalid colors generated by the m-position-probe docs

### DIFF
--- a/src/content/docs/m-position-probe/primary.mml
+++ b/src/content/docs/m-position-probe/primary.mml
@@ -20,7 +20,7 @@
     userCube.setAttribute("width", 0.25);
     userCube.setAttribute("height", 0.25);
     userCube.setAttribute("depth", 0.25);
-    userCube.setAttribute("color", `#${(Math.floor(Math.random() * 0xffffff) + 0x1000000).toString(16).substring(1)}`);
+    userCube.setAttribute("color", `#${Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0')}`);
     userPresenceHolder.append(userCube);
     const newUser = {
       cube: userCube,

--- a/src/content/docs/m-position-probe/primary.mml
+++ b/src/content/docs/m-position-probe/primary.mml
@@ -20,7 +20,7 @@
     userCube.setAttribute("width", 0.25);
     userCube.setAttribute("height", 0.25);
     userCube.setAttribute("depth", 0.25);
-    userCube.setAttribute("color", `#${Math.floor(Math.random() * 0xffffff).toString(16)}`);
+    userCube.setAttribute("color", `#${(Math.floor(Math.random() * 0xffffff) + 0x1000000).toString(16).substring(1)}`);
     userPresenceHolder.append(userCube);
     const newUser = {
       cube: userCube,


### PR DESCRIPTION
This PR fixes invalid colors generated by the `<m-position-probe>` docs when values with less than 6 digits were generated.

**What kind of change does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [X] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
