### PR TITLE
Quick fix for blog posts height

### DIFF
--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -8,14 +8,14 @@ const DocsPage = () => {
   return (
     <>
       <Head>{getPageTitle("Blog")}</Head>
-      <main className="mx-auto mt-32 max-w-[450px] px-4 sm:max-w-[575px] sm:px-0 md:max-w-[768px] lg:max-w-[992px] lg:max-w-[992px] xl:max-w-[1200px] 2xl:max-w-[1300px]">
+      <main className="mx-auto mt-32 max-w-[450px] px-4 sm:max-w-[575px] sm:px-0 md:max-w-[768px] lg:max-w-[992px] xl:max-w-[1200px] 2xl:max-w-[1300px]">
         <h1 className="text-4xl font-semibold">Blog</h1>
-        <div className="flex flex-wrap justify-center xl:justify-between">
+        <div className="flex flex-wrap items-stretch justify-center xl:justify-between">
           {Object.entries(posts).map(([key, { title, description, image }]) => (
             <Link key={key} href={`/blog/${key}`} className="xl:max-w-[49%]">
-              <div className="mt-9 w-full flex-1 border-[1px] border-editor-border dark:border-editor-border-dark">
+              <div className="mt-9 flex h-[calc(100%-36px)] w-full flex-1 flex-col border-[1px] border-editor-border dark:border-editor-border-dark">
                 <img className="w-full" src={image} alt={title} width={620} height={321} />
-                <div className="p-8 dark:bg-editor-bg">
+                <div className="h-full flex-1 p-8 dark:bg-editor-bg">
                   <p className="text-2xl font-medium">{title}</p>
                   <p className="mt-4">{description}</p>
                 </div>


### PR DESCRIPTION
This PR fixes the visual issue of blog posts in on `/blog` not having the same height.

<img width="1346" alt="image" src="https://github.com/mml-io/mml-website/assets/17921985/7e8f73b2-d81e-49fa-9821-c46fdde7a471">


**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
