### PR TITLE
Add event docs examples #64

### DIFF
--- a/src/components/AnimatedExampleView/ExampleClient.tsx
+++ b/src/components/AnimatedExampleView/ExampleClient.tsx
@@ -14,7 +14,7 @@ export const ExampleClient = React.memo(function ExampleClient(props: {
   document: NetworkedDOM | EditableNetworkedDOM;
   clientId: number;
   children?: React.ReactNode;
-  clientsNumber: number;
+  clientsNumber?: number;
 }) {
   const [clientState, setClientState] = useState<{
     client: MMLWebRunnerClient;
@@ -62,7 +62,7 @@ export const ExampleClient = React.memo(function ExampleClient(props: {
     clientState?.scene.fitContainer();
   }, 1);
 
-  const { children, clientsNumber, clientId } = props;
+  const { children, clientsNumber = 1, clientId } = props;
 
   const clientHeight = Math.floor(368 / clientsNumber);
 

--- a/src/components/AnimatedExampleView/ExampleClient.tsx
+++ b/src/components/AnimatedExampleView/ExampleClient.tsx
@@ -70,9 +70,9 @@ export const ExampleClient = React.memo(function ExampleClient(props: {
     <>
       <div className="relative h-[35px] w-full border-b-[1px] border-editor-border bg-white dark:border-editor-border-dark dark:bg-editor-bg">
         {children}
-        <span className="inline-block h-full w-[83px] border-b-[3px] bg-transparent pt-2 text-center text-[13px] text-editor-title">
-          Client {clientId + 1}
-        </span>
+        {/*<span className="inline-block h-full w-[83px] border-b-[3px] bg-transparent pt-2 text-center text-[13px] text-editor-title">*/}
+        {/*  Client {clientId + 1}*/}
+        {/*</span>*/}
       </div>
       <Container clientHeight={clientHeight} refProp={elementRef} />
     </>

--- a/src/components/AnimatedExampleView/ExampleClient.tsx
+++ b/src/components/AnimatedExampleView/ExampleClient.tsx
@@ -62,7 +62,7 @@ export const ExampleClient = React.memo(function ExampleClient(props: {
     clientState?.scene.fitContainer();
   }, 1);
 
-  const { children, clientsNumber = 1, clientId } = props;
+  const { children, clientsNumber = 1 } = props;
 
   const clientHeight = Math.floor(368 / clientsNumber);
 
@@ -70,9 +70,9 @@ export const ExampleClient = React.memo(function ExampleClient(props: {
     <>
       <div className="relative h-[35px] w-full border-b-[1px] border-editor-border bg-white dark:border-editor-border-dark dark:bg-editor-bg">
         {children}
-        {/*<span className="inline-block h-full w-[83px] border-b-[3px] bg-transparent pt-2 text-center text-[13px] text-editor-title">*/}
-        {/*  Client {clientId + 1}*/}
-        {/*</span>*/}
+        <span className="inline-block h-full w-[83px] border-b-[3px] bg-transparent pt-2 text-center text-[13px] text-editor-title">
+          Client
+        </span>
       </div>
       <Container clientHeight={clientHeight} refProp={elementRef} />
     </>

--- a/src/components/AnimatedExampleView/ExampleClient.tsx
+++ b/src/components/AnimatedExampleView/ExampleClient.tsx
@@ -6,17 +6,20 @@ import { useEffect, useState } from "react";
 
 import { getIframeTargetWindow } from "@/src/util/iframe-target";
 
-function Container(props: { refProp: React.Ref<HTMLDivElement> }) {
-  return <div className={"h-[100%] w-[100%]"} ref={props.refProp} />;
+function Container(props: { refProp: React.Ref<HTMLDivElement>; clientHeight: number }) {
+  return <div style={{ height: props.clientHeight - 35 }} ref={props.refProp} />;
 }
 
 export const ExampleClient = React.memo(function ExampleClient(props: {
   document: NetworkedDOM | EditableNetworkedDOM;
   clientId: number;
+  children?: React.ReactNode;
+  clientsNumber: number;
 }) {
   const [clientState, setClientState] = useState<{
     client: MMLWebRunnerClient;
     scene: MMLScene;
+    children?: React.ReactNode;
   } | null>(null);
   const elementRef = React.useRef<HTMLDivElement>(null);
 
@@ -58,14 +61,20 @@ export const ExampleClient = React.memo(function ExampleClient(props: {
   setTimeout(() => {
     clientState?.scene.fitContainer();
   }, 1);
+
+  const { children, clientsNumber, clientId } = props;
+
+  const clientHeight = Math.floor(368 / clientsNumber);
+
   return (
     <>
-      <div className="h-[35px] w-full border-b-[1px] border-editor-border bg-white dark:border-editor-border-dark dark:bg-editor-bg">
+      <div className="relative h-[35px] w-full border-b-[1px] border-editor-border bg-white dark:border-editor-border-dark dark:bg-editor-bg">
+        {children}
         <span className="inline-block h-full w-[83px] border-b-[3px] bg-transparent pt-2 text-center text-[13px] text-editor-title">
-          Client {props.clientId + 1}
+          Client {clientId + 1}
         </span>
       </div>
-      <Container refProp={elementRef} />
+      <Container clientHeight={clientHeight} refProp={elementRef} />
     </>
   );
 });

--- a/src/components/ExampleView/DocsExampleView.tsx
+++ b/src/components/ExampleView/DocsExampleView.tsx
@@ -15,13 +15,15 @@ function createDocumentCode(code: string, lightOn: boolean): string {
   }${code}`;
 }
 
-export function DocsExampleView(props: {
+export type DocsExampleViewProps = {
   code: string;
   initialClientCount?: number;
   baseScene: boolean;
   description: string;
   showClientsControls?: boolean;
-}) {
+};
+
+export function DocsExampleView(props: DocsExampleViewProps) {
   const [code, setCode] = useState(props.code);
   const [networkedDOMDocument, setNetworkedDOMDocument] = useState<EditableNetworkedDOM | null>(
     null,

--- a/src/components/ExampleView/DocsExampleView.tsx
+++ b/src/components/ExampleView/DocsExampleView.tsx
@@ -20,12 +20,16 @@ export function DocsExampleView(props: {
   initialClientCount?: number;
   baseScene: boolean;
   description: string;
+  showClientsControls?: boolean;
 }) {
   const [code, setCode] = useState(props.code);
   const [networkedDOMDocument, setNetworkedDOMDocument] = useState<EditableNetworkedDOM | null>(
     null,
   );
-  const clients = [...Array(props.initialClientCount || 1).keys()];
+  const [clients, setClients] = useState<number[]>([
+    ...Array(props.initialClientCount ?? 1).keys(),
+  ]);
+
   const { baseScene } = props;
 
   useEffect(() => {
@@ -49,6 +53,14 @@ export function DocsExampleView(props: {
   const handleResetClick = useCallback(() => {
     setCode(props.code);
   }, []);
+
+  const addNewClient = () => {
+    setClients((oldClients) => [...oldClients, oldClients.length]);
+  };
+
+  const removeClient = () => {
+    setClients((oldClients) => oldClients.slice(0, oldClients.length - 1));
+  };
 
   return (
     <>
@@ -79,9 +91,24 @@ export function DocsExampleView(props: {
         <div className="relative flex h-full flex-[0_0_40%] flex-col">
           {networkedDOMDocument && (
             <>
-              {clients.map((clientId) => {
+              {clients.map((clientId, index) => {
+                const isLast = index === clients.length - 1 && index !== 0;
                 return (
-                  <ExampleClient clientId={0} key={clientId} document={networkedDOMDocument} />
+                  <ExampleClient
+                    clientId={clientId}
+                    clientsNumber={clients.length}
+                    key={clientId}
+                    document={networkedDOMDocument}
+                  >
+                    {props.showClientsControls && (isLast || clientId === 0) && (
+                      <button
+                        className="absolute right-0 top-0 mr-1 mt-1 border-[1px] border-editor-border bg-white px-[10px] py-[3px] text-[13px] text-black dark:border-editor-border-dark dark:bg-editor-bg dark:text-white"
+                        onClick={isLast ? removeClient : addNewClient}
+                      >
+                        {isLast ? "remove client" : "Add new client"}
+                      </button>
+                    )}
+                  </ExampleClient>
                 );
               })}
             </>

--- a/src/components/ExampleView/DocsExampleView.tsx
+++ b/src/components/ExampleView/DocsExampleView.tsx
@@ -107,7 +107,7 @@ export function DocsExampleView(props: DocsExampleViewProps) {
                         className="absolute right-0 top-0 mr-1 mt-1 border-[1px] border-editor-border bg-white px-[10px] py-[3px] text-[13px] text-black dark:border-editor-border-dark dark:bg-editor-bg dark:text-white"
                         onClick={isLast ? removeClient : addNewClient}
                       >
-                        {isLast ? "remove client" : "Add new client"}
+                        {isLast ? "Remove client" : "Add new client"}
                       </button>
                     )}
                   </ExampleClient>

--- a/src/components/ExampleView/DocsExampleViewDynamic.tsx
+++ b/src/components/ExampleView/DocsExampleViewDynamic.tsx
@@ -1,29 +1,12 @@
 import dynamic from "next/dynamic";
 
-type ExampleViewProps = {
-  code: string;
-  baseScene?: boolean;
-  initialClientCount?: number;
-  description?: string;
-};
+import { DocsExampleViewProps } from "@/src/components/ExampleView/DocsExampleView";
 
-const ExampleViewStatic = dynamic<Partial<ExampleViewProps>>(
+const ExampleViewStatic = dynamic<Partial<DocsExampleViewProps>>(
   () => import("@/src/components/ExampleView/DocsExampleView").then((mod) => mod.DocsExampleView),
   { ssr: false },
 );
 
-export default function ExampleView({
-  code,
-  description,
-  baseScene,
-  initialClientCount,
-}: ExampleViewProps) {
-  return (
-    <ExampleViewStatic
-      baseScene={baseScene}
-      initialClientCount={initialClientCount ?? 1}
-      code={code}
-      description={description ?? "Demo"}
-    />
-  );
+export default function ExampleView(props: DocsExampleViewProps) {
+  return <ExampleViewStatic {...props} />;
 }

--- a/src/components/ExampleView/DocsExampleViewDynamic.tsx
+++ b/src/components/ExampleView/DocsExampleViewDynamic.tsx
@@ -1,6 +1,6 @@
 import dynamic from "next/dynamic";
 
-import { DocsExampleViewProps } from "@/src/components/ExampleView/DocsExampleView";
+import type { DocsExampleViewProps } from "@/src/components/ExampleView/DocsExampleView";
 
 const ExampleViewStatic = dynamic<Partial<DocsExampleViewProps>>(
   () => import("@/src/components/ExampleView/DocsExampleView").then((mod) => mod.DocsExampleView),

--- a/src/config/mdx.tsx
+++ b/src/config/mdx.tsx
@@ -1,4 +1,4 @@
-import { DetailedHTMLProps, HTMLProps, OlHTMLAttributes, ReactNode } from "react";
+import { DetailedHTMLProps, HTMLProps, OlHTMLAttributes } from "react";
 import ReactMarkdown from "react-markdown";
 import { Components } from "react-markdown/lib/ast-to-react";
 import { ReactMarkdownOptions } from "react-markdown/lib/react-markdown";

--- a/src/content/docs/connectionEvent/disconnected.mml
+++ b/src/content/docs/connectionEvent/disconnected.mml
@@ -1,0 +1,17 @@
+<m-label y="5" width="10" height="5" color="red" font-size="150">
+</m-label>
+
+<script>
+  const labelElement = document.querySelector("m-label")
+  const connections = new Set([1, 2]);
+  const connectionsString = Array.from(connections).join(", ")
+  labelElement.setAttribute("content", "Connected Ids: " + connectionsString)
+
+  window.addEventListener("disconnected", (e) => {
+    connections.delete(e.detail.connectionId)
+
+    const connectionsString = Array.from(connections).join(", ")
+
+    labelElement.setAttribute("content", "Connected Ids: " + connectionsString)
+  })
+</script>

--- a/src/content/docs/connectionEvent/index.ts
+++ b/src/content/docs/connectionEvent/index.ts
@@ -20,7 +20,7 @@ export const examples: DocsExamples = {
     showClientsControls: true,
   },
   visibleTo: {
-    title: "Basic visibleTo event",
+    title: "Visible to event",
     description: "A label that shows only the client id of one specific client",
     code: visibleTo,
     clientsNumber: 2,

--- a/src/content/docs/connectionEvent/index.ts
+++ b/src/content/docs/connectionEvent/index.ts
@@ -1,0 +1,29 @@
+import { DocsExamples } from "@/types/docs-reference";
+
+import disconnected from "./disconnected.mml";
+import primary from "./primary.mml";
+import visibleTo from "./visible-to.mml";
+
+export const examples: DocsExamples = {
+  primary: {
+    title: "Basic connection event",
+    description: "A label that shows the client ids that have connected.",
+    code: primary,
+    clientsNumber: 2,
+    showClientsControls: true,
+  },
+  test: {
+    title: "Basic disconnection event",
+    description: "A label that shows the client ids that have disconnected.",
+    code: disconnected,
+    clientsNumber: 2,
+    showClientsControls: true,
+  },
+  visibleTo: {
+    title: "Basic visibleTo event",
+    description: "A label that shows only the client id of one specific client",
+    code: visibleTo,
+    clientsNumber: 2,
+    showClientsControls: true,
+  },
+};

--- a/src/content/docs/connectionEvent/primary.mml
+++ b/src/content/docs/connectionEvent/primary.mml
@@ -1,0 +1,15 @@
+<m-label y="5" width="10" height="5" color="red" font-size="150">
+</m-label>
+
+<script>
+  const connections = new Set();
+
+  window.addEventListener("connected", (e) => {
+    const labelElement = document.querySelector("m-label")
+    connections.add(e.detail.connectionId)
+
+    const connectionsString = Array.from(connections).join(", ")
+
+    labelElement.setAttribute("content", "Connected Ids: " + connectionsString)
+  })
+</script>

--- a/src/content/docs/connectionEvent/visible-to.mml
+++ b/src/content/docs/connectionEvent/visible-to.mml
@@ -6,7 +6,7 @@
   window.addEventListener("connected", (e) => {
     const newLabel = document.createElement("m-label")
 
-    newLabel.setAttribute("id", e.detail.connectionId)
+    newLabel.setAttribute("id", `#client-${e.detail.connectionId}`)
     newLabel.setAttribute("y", "5")
     newLabel.setAttribute("width", "10")
     newLabel.setAttribute("height", "4")
@@ -20,7 +20,7 @@
   })
 
   window.addEventListener("disconnected", (e) => {
-    const label = document.querySelector(`#${e.detail.connectionId}`)
+    const label = document.querySelector(`#client-${e.detail.connectionId}`)
 
     labelGroup.removeChild(label)
   })

--- a/src/content/docs/connectionEvent/visible-to.mml
+++ b/src/content/docs/connectionEvent/visible-to.mml
@@ -1,0 +1,27 @@
+<m-group id="label-group"></m-group>
+
+<script>
+  const labelGroup = document.querySelector("#label-group")
+
+  window.addEventListener("connected", (e) => {
+    const newLabel = document.createElement("m-label")
+
+    newLabel.setAttribute("id", e.detail.connectionId)
+    newLabel.setAttribute("y", "5")
+    newLabel.setAttribute("width", "10")
+    newLabel.setAttribute("height", "4")
+    newLabel.setAttribute("color", "red")
+    newLabel.setAttribute("font-size", "300")
+    newLabel.setAttribute("alignment", "center")
+    newLabel.setAttribute("visible-to", e.detail.connectionId)
+    newLabel.setAttribute("content", e.detail.connectionId)
+
+    labelGroup.appendChild(newLabel)
+  })
+
+  window.addEventListener("disconnected", (e) => {
+    const label = document.querySelector(`#${e.detail.connectionId}`)
+
+    labelGroup.removeChild(label)
+  })
+</script>

--- a/src/content/docs/index.ts
+++ b/src/content/docs/index.ts
@@ -1,5 +1,6 @@
 import { DocsExamplesByTag } from "@/types/docs-reference";
 
+import * as connectionEvent from "./connectionEvent";
 import * as mAttrAnim from "./m-attr-anim";
 import * as mAudio from "./m-audio";
 import * as mCharacter from "./m-character";
@@ -16,6 +17,16 @@ import * as mPositionProbe from "./m-position-probe";
 import * as mPrompt from "./m-prompt";
 import * as mSphere from "./m-sphere";
 import * as mVideo from "./m-video";
+import * as mmlChatEvent from "./mmlChatEvent";
+import * as mmlClickEvent from "./mmlClickEvent";
+import * as mmlCollisionEndEvent from "./mmlCollisionEndEvent";
+import * as mmlCollisionMoveEvent from "./mmlCollisionMoveEvent";
+import * as mmlCollisionStartEvent from "./mmlCollisionStartEvent";
+import * as mmlInteractionEvent from "./mmlInteractionEvent";
+import * as mmlPositionEnterEvent from "./mmlPositionEnterEvent";
+import * as mmlPositionLeaveEvent from "./mmlPositionLeaveEvent";
+import * as mmlPositionMoveEvent from "./mmlPositionMoveEvent";
+import * as mmlPromptEvent from "./mmlPromptEvent";
 
 export const examples: DocsExamplesByTag = {
   "m-cube": mCube,
@@ -34,4 +45,15 @@ export const examples: DocsExamplesByTag = {
   "m-position-probe": mPositionProbe,
   "m-attr-anim": mAttrAnim,
   "m-image": mImage,
+  ConnectionEvent: connectionEvent,
+  MMLChatEvent: mmlChatEvent,
+  MMLClickEvent: mmlClickEvent,
+  MMLCollisionEndEvent: mmlCollisionEndEvent,
+  MMLCollisionMoveEvent: mmlCollisionMoveEvent,
+  MMLCollisionStartEvent: mmlCollisionStartEvent,
+  MMLInteractionEvent: mmlInteractionEvent,
+  MMLPositionEnterEvent: mmlPositionEnterEvent,
+  MMLPositionLeaveEvent: mmlPositionLeaveEvent,
+  MMLPositionMoveEvent: mmlPositionMoveEvent,
+  MMLPromptEvent: mmlPromptEvent,
 };

--- a/src/content/docs/mmlChatEvent/index.ts
+++ b/src/content/docs/mmlChatEvent/index.ts
@@ -1,0 +1,3 @@
+import { DocsExamples } from "@/types/docs-reference";
+
+export const examples: DocsExamples = {};

--- a/src/content/docs/mmlClickEvent/clicked-by.mml
+++ b/src/content/docs/mmlClickEvent/clicked-by.mml
@@ -1,0 +1,13 @@
+<m-cube id="cube" y="1" width="2" height="2" depth="2" color="black">
+</m-cube>
+<m-label y="5" width="10" height="5" color="red" font-size="180" content="Click the cube!">
+</m-label>
+
+<script>
+  const cube = document.querySelector("#cube")
+
+  cube.addEventListener("click", (e) => {
+    const label = document.querySelector("m-label")
+    label.setAttribute("content", "Clicked by: " + e.detail.connectionId)
+  })
+</script>

--- a/src/content/docs/mmlClickEvent/index.ts
+++ b/src/content/docs/mmlClickEvent/index.ts
@@ -1,0 +1,25 @@
+import { DocsExamples } from "@/types/docs-reference";
+
+import clickedBy from "./clicked-by.mml";
+import position from "./position.mml";
+import primary from "./primary.mml";
+
+export const examples: DocsExamples = {
+  primary: {
+    title: "Basic click event",
+    description: "This is a basic click event.",
+    code: primary,
+  },
+  clickedBy: {
+    title: "Clicked by",
+    description: "This example shows which client clicked the cube.",
+    code: clickedBy,
+    clientsNumber: 2,
+    showClientsControls: true,
+  },
+  position: {
+    title: "Position",
+    description: "This example shows the position of the click event.",
+    code: position,
+  },
+};

--- a/src/content/docs/mmlClickEvent/position.mml
+++ b/src/content/docs/mmlClickEvent/position.mml
@@ -1,0 +1,17 @@
+<m-cube id="cube" y="1" width="2" height="2" depth="2" color="black">
+</m-cube>
+<m-label y="5" width="10" height="5" color="red" font-size="120" content="Click the cube!">
+</m-label>
+
+<script>
+  const cube = document.querySelector("#cube")
+
+  const getShortPosition = str => str.toString().substring(0, 6)
+
+  cube.addEventListener("click", (e) => {
+    const label = document.querySelector("m-label")
+    const { position } = e.detail
+
+    label.setAttribute("content", "Clicked at: \n" + "x: " + getShortPosition(position.x) + ",\ny: " + getShortPosition(position.y) + ",\nz: " + getShortPosition(position.z))
+  })
+</script>

--- a/src/content/docs/mmlClickEvent/primary.mml
+++ b/src/content/docs/mmlClickEvent/primary.mml
@@ -1,0 +1,13 @@
+<m-cube id="cube" y="2" color="red">
+</m-cube>
+
+<script>
+  const cube = document.querySelector("#cube")
+
+  cube.addEventListener("click", (e) => {
+    // let's create a random new color
+    const newColor = "#" + Math.floor(Math.random() * 16777215).toString(16)
+    // and set it as the new color of the cube
+    cube.setAttribute("color", newColor)
+  })
+</script>

--- a/src/content/docs/mmlCollisionEndEvent/index.ts
+++ b/src/content/docs/mmlCollisionEndEvent/index.ts
@@ -1,0 +1,3 @@
+import { DocsExamples } from "@/types/docs-reference";
+
+export const examples: DocsExamples = {};

--- a/src/content/docs/mmlCollisionMoveEvent/index.ts
+++ b/src/content/docs/mmlCollisionMoveEvent/index.ts
@@ -1,0 +1,3 @@
+import { DocsExamples } from "@/types/docs-reference";
+
+export const examples: DocsExamples = {};

--- a/src/content/docs/mmlCollisionStartEvent/index.ts
+++ b/src/content/docs/mmlCollisionStartEvent/index.ts
@@ -1,0 +1,3 @@
+import { DocsExamples } from "@/types/docs-reference";
+
+export const examples: DocsExamples = {};

--- a/src/content/docs/mmlInteractionEvent/index.ts
+++ b/src/content/docs/mmlInteractionEvent/index.ts
@@ -1,0 +1,3 @@
+import { DocsExamples } from "@/types/docs-reference";
+
+export const examples: DocsExamples = {};

--- a/src/content/docs/mmlPositionEnterEvent/index.ts
+++ b/src/content/docs/mmlPositionEnterEvent/index.ts
@@ -1,0 +1,3 @@
+import { DocsExamples } from "@/types/docs-reference";
+
+export const examples: DocsExamples = {};

--- a/src/content/docs/mmlPositionLeaveEvent/index.ts
+++ b/src/content/docs/mmlPositionLeaveEvent/index.ts
@@ -1,0 +1,3 @@
+import { DocsExamples } from "@/types/docs-reference";
+
+export const examples: DocsExamples = {};

--- a/src/content/docs/mmlPositionMoveEvent/index.ts
+++ b/src/content/docs/mmlPositionMoveEvent/index.ts
@@ -1,0 +1,3 @@
+import { DocsExamples } from "@/types/docs-reference";
+
+export const examples: DocsExamples = {};

--- a/src/content/docs/mmlPromptEvent/index.ts
+++ b/src/content/docs/mmlPromptEvent/index.ts
@@ -1,0 +1,11 @@
+import { DocsExamples } from "@/types/docs-reference";
+
+import primary from "./primary.mml";
+
+export const examples: DocsExamples = {
+  primary: {
+    title: "Basic connection event",
+    description: "This is a basic connection event.",
+    code: primary,
+  },
+};

--- a/src/content/docs/mmlPromptEvent/primary.mml
+++ b/src/content/docs/mmlPromptEvent/primary.mml
@@ -1,0 +1,25 @@
+<m-prompt
+  message="What is your favourite color?"
+  placeholder="Write a color"
+  prefill="orange"
+  id="my-prompt"
+  y="2"
+>
+  <m-cube id="color-cube" color="blue"></m-cube>
+</m-prompt>
+
+<m-label id="my-label" y="5" width="10" content="Hello World!" font-size="80" alignment="center" color="#BBB" font-color="#000"></m-label>
+
+<script>
+  const mPrompt = document.getElementById("my-prompt");
+  const mLabel = document.getElementById("my-label");
+  const mCube = document.getElementById("color-cube");
+
+  function handlePrompt(e) {
+    const color = e.detail.value;
+    mLabel.setAttribute("content", color);
+    mCube.setAttribute("color", color);
+  }
+
+  mPrompt.addEventListener("prompt", handlePrompt);
+</script>

--- a/src/pages/docs/reference/events/[event-id].tsx
+++ b/src/pages/docs/reference/events/[event-id].tsx
@@ -1,4 +1,5 @@
 import { EventsClassSchemaType, EventType } from "@mml-io/mml-schema";
+import dynamic from "next/dynamic";
 import Head from "next/head";
 import Link from "next/link";
 import * as React from "react";
@@ -10,6 +11,8 @@ import Breadcrumb from "@/src/components/Common/Breadcrumb";
 import LinkList from "@/src/components/Common/LinkList";
 import ReferenceNavigation from "@/src/components/Common/ReferenceNavigation";
 import TypeDocComment from "@/src/components/TypeDocComment";
+import { MarkDown } from "@/src/config/mdx";
+import * as docsExamples from "@/src/content/docs";
 import { getPageTitle } from "@/src/util";
 import { eventClasses } from "@/src/util/event-classes";
 
@@ -37,6 +40,13 @@ export function getStaticProps({ params }: { params: { "event-id": string } }) {
   return { props: { eventId } };
 }
 
+const ExampleView = dynamic(
+  () => import("@/src/components/ExampleView/DocsExampleView").then((mod) => mod.DocsExampleView),
+  {
+    ssr: false,
+  },
+);
+
 function isReference(type: { type: string }): type is ReferenceType {
   return type.type === "reference";
 }
@@ -60,6 +70,12 @@ const DocsPage = ({ eventId }: { eventId: string }) => {
     }
   }
 
+  let primaryExample = null;
+  const examplesForElement = docsExamples.examples[eventId];
+  if (examplesForElement && examplesForElement.examples.primary) {
+    primaryExample = examplesForElement.examples.primary;
+  }
+
   const createTypeLink = (type: string, index: number) => {
     if (getEventClass(type)) {
       return (
@@ -71,6 +87,10 @@ const DocsPage = ({ eventId }: { eventId: string }) => {
 
     return type;
   };
+
+  const filteredExamples = examplesForElement
+    ? Object.keys(examplesForElement.examples).filter((key) => key !== "primary")
+    : [];
 
   return (
     <>
@@ -96,6 +116,23 @@ const DocsPage = ({ eventId }: { eventId: string }) => {
             {eventClassDefinition.comment && (
               <TypeDocComment comment={eventClassDefinition.comment} />
             )}
+            {primaryExample && (
+              <>
+                <h2 className="mb-4 mt-8 scroll-m-20 text-3xl font-medium" id="try it">
+                  Try it
+                </h2>
+                <ExampleView
+                  description="Demo"
+                  key={`${eventId}-primary`}
+                  baseScene={
+                    primaryExample.baseSceneOn !== undefined ? primaryExample.baseSceneOn : true
+                  }
+                  code={primaryExample.code}
+                  initialClientCount={primaryExample?.clientsNumber ?? 1}
+                  showClientsControls={primaryExample?.showClientsControls}
+                />
+              </>
+            )}
             <h2 className="mb-4 mt-6 scroll-m-20 text-3xl font-medium" id="properties">
               Properties
             </h2>
@@ -105,10 +142,7 @@ const DocsPage = ({ eventId }: { eventId: string }) => {
                   if (!showExternalProperties && property.flags.isExternal) {
                     return false;
                   }
-                  if (!showInheritedProperties && property.inheritedFrom) {
-                    return false;
-                  }
-                  return true;
+                  return !(!showInheritedProperties && property.inheritedFrom);
                 })
                 .map((property) => (
                   <div key={property.name}>
@@ -142,6 +176,29 @@ const DocsPage = ({ eventId }: { eventId: string }) => {
                     <h3 className="mb-2 text-xl uppercase">{eventClass.name}</h3>
                   </div>
                 ))}
+              </>
+            )}
+            {filteredExamples.length > 0 && (
+              <>
+                <h2 id="examples" className="mb-4 mt-6 scroll-m-20 text-3xl font-medium">
+                  Examples
+                </h2>
+                {filteredExamples.map((exampleKey) => {
+                  const example = examplesForElement.examples[exampleKey];
+                  return (
+                    <div key={`${eventId}-${example.title}`}>
+                      <h3 className="mt-8 text-[24px] font-medium">{example.title}</h3>
+                      <MarkDown>{`${example.description}`}</MarkDown>
+                      <ExampleView
+                        description={example.title}
+                        baseScene={example.baseSceneOn !== undefined ? example.baseSceneOn : true}
+                        code={example.code}
+                        initialClientCount={example?.clientsNumber ?? 1}
+                        showClientsControls={example?.showClientsControls}
+                      />
+                    </div>
+                  );
+                })}
               </>
             )}
           </main>

--- a/src/pages/docs/reference/events/[event-id].tsx
+++ b/src/pages/docs/reference/events/[event-id].tsx
@@ -1,5 +1,4 @@
 import { EventsClassSchemaType, EventType } from "@mml-io/mml-schema";
-import dynamic from "next/dynamic";
 import Head from "next/head";
 import Link from "next/link";
 import * as React from "react";
@@ -10,6 +9,7 @@ import { ReferenceType, ReflectionType } from "typedoc";
 import Breadcrumb from "@/src/components/Common/Breadcrumb";
 import LinkList from "@/src/components/Common/LinkList";
 import ReferenceNavigation from "@/src/components/Common/ReferenceNavigation";
+import ExampleView from "@/src/components/ExampleView/DocsExampleViewDynamic";
 import TypeDocComment from "@/src/components/TypeDocComment";
 import { MarkDown } from "@/src/config/mdx";
 import * as docsExamples from "@/src/content/docs";
@@ -39,13 +39,6 @@ export function getStaticProps({ params }: { params: { "event-id": string } }) {
   // Pass post data to the page via props
   return { props: { eventId } };
 }
-
-const ExampleView = dynamic(
-  () => import("@/src/components/ExampleView/DocsExampleView").then((mod) => mod.DocsExampleView),
-  {
-    ssr: false,
-  },
-);
 
 function isReference(type: { type: string }): type is ReferenceType {
   return type.type === "reference";

--- a/types/docs-reference.ts
+++ b/types/docs-reference.ts
@@ -3,6 +3,8 @@ export type DocsReference = {
   description: string;
   code: string;
   baseSceneOn?: boolean;
+  clientsNumber?: number;
+  showClientsControls?: boolean;
 };
 
 export type DocsExamples = {


### PR DESCRIPTION
Resolves #64 

Adds examples for the events docs page
Improves DocsExampleView.tsx to add/remove clients
Adds individual examples where possible and folders for all the other events

**What kind of change does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [x] The title references the corresponding issue # (if relevant)
