### PR TITLE
Add Avatar Client to Examples #67

### DIFF
--- a/src/components/AnimatedExampleView/ExampleAvatarClient.tsx
+++ b/src/components/AnimatedExampleView/ExampleAvatarClient.tsx
@@ -1,6 +1,6 @@
 import { EditableNetworkedDOM, NetworkedDOM } from "@mml-io/networked-dom-document";
 import * as React from "react";
-import { useEffect, useState } from "react";
+import { CSSProperties, useEffect, useState } from "react";
 import { Euler, Vector3 } from "three";
 
 import { getIframeTargetWindow } from "@/src/util/iframe-target";
@@ -8,8 +8,13 @@ import { getIframeTargetWindow } from "@/src/util/iframe-target";
 import { LocalAvatarClient } from "./LocalAvatar/LocalAvatarClient";
 import { LocalAvatarServer } from "./LocalAvatar/LocalAvatarServer";
 
-function Container(props: { refProp: React.Ref<HTMLDivElement> }) {
-  return <div className={"h-[100%]"} ref={props.refProp} />;
+function Container(props: { refProp: React.Ref<HTMLDivElement>; clientHeight?: number }) {
+  return (
+    <div
+      ref={props.refProp}
+      style={props.clientHeight ? { height: props.clientHeight - 35 } : undefined}
+    />
+  );
 }
 
 export const ExampleAvatarClient = React.memo(function ExampleAvatarClient(props: {
@@ -18,6 +23,10 @@ export const ExampleAvatarClient = React.memo(function ExampleAvatarClient(props
   clientId: number;
   position: { x: number; y: number; z: number };
   rotation: { x: number; y: number; z: number };
+  children?: React.ReactNode;
+  containerStyle?: CSSProperties;
+  clientsNumber?: number;
+  parentHeight?: number;
 }) {
   const [client, setClient] = useState<LocalAvatarClient | null>(null);
   const elementRef = React.useRef<HTMLDivElement>(null);
@@ -50,6 +59,7 @@ export const ExampleAvatarClient = React.memo(function ExampleAvatarClient(props
 
   useEffect(() => {
     if (elementRef.current && client) {
+      client.element.setAttribute("style", "height: 100%");
       elementRef.current.appendChild(client.element);
     }
   }, [elementRef.current, client]);
@@ -58,14 +68,20 @@ export const ExampleAvatarClient = React.memo(function ExampleAvatarClient(props
     return null;
   }
 
+  const { children, clientsNumber = 1, parentHeight = 368 } = props;
+
+  // 368 is the client height we're using in the docs, we use it as a default value here
+  const clientHeight = Math.floor(parentHeight / clientsNumber);
+
   return (
     <>
-      <div className="h-[35px] w-full border-b-[1px] border-editor-border bg-white dark:border-editor-border-dark dark:bg-editor-bg">
+      <div className="relative h-[35px] w-full border-b-[1px] border-editor-border bg-white dark:border-editor-border-dark dark:bg-editor-bg">
+        {children}
         <span className="inline-block h-full w-[83px] border-b-[3px] bg-transparent pt-2 text-center text-[13px] text-editor-title">
-          Client {props.clientId + 1}
+          Client
         </span>
       </div>
-      <Container refProp={elementRef} />
+      <Container clientHeight={clientHeight} refProp={elementRef} />
     </>
   );
 });

--- a/src/components/AnimatedExampleView/ExampleClient.tsx
+++ b/src/components/AnimatedExampleView/ExampleClient.tsx
@@ -15,6 +15,7 @@ export const ExampleClient = React.memo(function ExampleClient(props: {
   clientId: number;
   children?: React.ReactNode;
   clientsNumber?: number;
+  parentHeight?: number;
 }) {
   const [clientState, setClientState] = useState<{
     client: MMLWebRunnerClient;
@@ -62,9 +63,10 @@ export const ExampleClient = React.memo(function ExampleClient(props: {
     clientState?.scene.fitContainer();
   }, 1);
 
-  const { children, clientsNumber = 1 } = props;
+  // 368 is the client height we're using in the docs, we use it as a default value here
+  const { children, clientsNumber = 1, parentHeight = 368 } = props;
 
-  const clientHeight = Math.floor(368 / clientsNumber);
+  const clientHeight = Math.floor(parentHeight / clientsNumber);
 
   return (
     <>

--- a/src/components/ExampleView/ExamplePageExampleView.tsx
+++ b/src/components/ExampleView/ExamplePageExampleView.tsx
@@ -1,10 +1,13 @@
 import { EditableNetworkedDOM } from "@mml-io/networked-dom-document";
 import { IframeObservableDOMFactory } from "@mml-io/networked-dom-web-runner";
 import * as React from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
+import { ExampleAvatarClient } from "@/src/components/AnimatedExampleView/ExampleAvatarClient";
 import { ExampleClient } from "@/src/components/AnimatedExampleView/ExampleClient";
+import { LocalAvatarServer } from "@/src/components/AnimatedExampleView/LocalAvatar/LocalAvatarServer";
 import HTMLEditor from "@/src/components/ExampleView/HTMLEditor";
+import { CLIENT_TYPES, ClientType } from "@/types/docs-reference";
 
 function createDocumentCode(code: string, lightOn: boolean): string {
   return `${
@@ -15,7 +18,7 @@ function createDocumentCode(code: string, lightOn: boolean): string {
 
 export function ExamplePageExampleView(props: {
   code: string;
-  initialClientCount?: number;
+  initialClients?: ClientType[];
   baseScene: boolean;
   description: string;
 }) {
@@ -23,8 +26,8 @@ export function ExamplePageExampleView(props: {
   const [networkedDOMDocument, setNetworkedDOMDocument] = useState<EditableNetworkedDOM | null>(
     null,
   );
-  const clients = [...Array(props.initialClientCount || 1).keys()];
-  const { baseScene } = props;
+  const { baseScene, initialClients = [CLIENT_TYPES.FLOATING] } = props;
+  const server = useRef(new LocalAvatarServer());
 
   useEffect(() => {
     const document = new EditableNetworkedDOM(
@@ -81,9 +84,25 @@ export function ExamplePageExampleView(props: {
         <div className="relative flex h-full flex-[0_1_40%] flex-col">
           {networkedDOMDocument && (
             <>
-              {clients.map((clientId) => {
-                return (
-                  <ExampleClient clientId={0} key={clientId} document={networkedDOMDocument} />
+              {initialClients.map((clientType, index) => {
+                return clientType === CLIENT_TYPES.FLOATING ? (
+                  <ExampleClient
+                    clientId={index}
+                    parentHeight={740}
+                    clientsNumber={initialClients.length}
+                    key={index}
+                    document={networkedDOMDocument}
+                  />
+                ) : (
+                  <ExampleAvatarClient
+                    server={server.current}
+                    clientsNumber={initialClients.length}
+                    parentHeight={740}
+                    document={networkedDOMDocument}
+                    clientId={index}
+                    position={{ x: -0.5, y: 0.5, z: 5 }}
+                    rotation={{ x: 0, y: Math.PI, z: 0 }}
+                  />
                 );
               })}
             </>

--- a/src/components/ExampleView/ExamplePageExampleViewDynamic.tsx
+++ b/src/components/ExampleView/ExamplePageExampleViewDynamic.tsx
@@ -1,10 +1,13 @@
 import dynamic from "next/dynamic";
 
+import { ClientType } from "@/types/docs-reference";
+
 type ExampleViewProps = {
   code: string;
+  initialClients: ClientType[];
   baseScene?: boolean;
-  initialClientCount?: number;
-  description?: string;
+  description: string;
+  showClientsControls?: boolean;
 };
 
 const ExamplePageExampleViewStatic = dynamic<Partial<ExampleViewProps>>(
@@ -15,18 +18,6 @@ const ExamplePageExampleViewStatic = dynamic<Partial<ExampleViewProps>>(
   { ssr: false },
 );
 
-export default function ExamplePageExampleView({
-  code,
-  description,
-  baseScene,
-  initialClientCount,
-}: ExampleViewProps) {
-  return (
-    <ExamplePageExampleViewStatic
-      baseScene={baseScene}
-      initialClientCount={initialClientCount ?? 1}
-      code={code}
-      description={description ?? "Demo"}
-    />
-  );
+export default function ExamplePageExampleView(props: ExampleViewProps) {
+  return <ExamplePageExampleViewStatic {...props} />;
 }

--- a/src/content/blogPosts/introducing-mml/body.mdx
+++ b/src/content/blogPosts/introducing-mml/body.mdx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import DocsExampleView from "@/src/components/ExampleView/DocsExampleViewDynamic";
+import { CLIENT_TYPES } from "@/types/docs-reference";
 
 # Introducing MML: An Open Source Metaverse Markup Language for Multi-User Interactive 3D Experiences
 _[Marcus Longmuir](https://twitter.com/marcuslongmuir) - 2023-06-15_
@@ -54,7 +55,7 @@ demonstrating one document seen by multiple clients complete with live editing. 
 some attributes:
 
 <div className="w-full lg:w-[992px] xl:w-[1200px] 2xl:w-[1300px] relative -translate-x-1/2 left-1/2 mt-8">
-  <DocsExampleView initialClientCount={2} code={`<m-plane color="green" width="20" height="20" rx="-90"></m-plane>
+  <DocsExampleView description="Demo" initialClients={[CLIENT_TYPES.FLOATING, CLIENT_TYPES.FLOATING]} code={`<m-plane color="green" width="20" height="20" rx="-90"></m-plane>
     <m-light type="spotlight" ry="45" rx="65" rz="-45" x="10" y="10" z="10"></m-light>
     <m-cube y="2" id="my-cube" color="red"></m-cube>
     <m-model x="2" y="1.25" src="https://public.mml.io/duck.glb"></m-cube>

--- a/src/content/docs/connectionEvent/index.ts
+++ b/src/content/docs/connectionEvent/index.ts
@@ -1,4 +1,4 @@
-import { DocsExamples } from "@/types/docs-reference";
+import { CLIENT_TYPES, DocsExamples } from "@/types/docs-reference";
 
 import disconnected from "./disconnected.mml";
 import primary from "./primary.mml";
@@ -9,21 +9,21 @@ export const examples: DocsExamples = {
     title: "Basic connection event",
     description: "A label that shows the client ids that have connected.",
     code: primary,
-    clientsNumber: 2,
+    clients: [CLIENT_TYPES.FLOATING, CLIENT_TYPES.FLOATING],
     showClientsControls: true,
   },
   test: {
     title: "Basic disconnection event",
     description: "A label that shows the client ids that have disconnected.",
     code: disconnected,
-    clientsNumber: 2,
+    clients: [CLIENT_TYPES.FLOATING, CLIENT_TYPES.FLOATING],
     showClientsControls: true,
   },
   visibleTo: {
     title: "Visible to event",
     description: "A label that shows only the client id of one specific client",
     code: visibleTo,
-    clientsNumber: 2,
+    clients: [CLIENT_TYPES.FLOATING, CLIENT_TYPES.FLOATING],
     showClientsControls: true,
   },
 };

--- a/src/content/docs/mmlClickEvent/index.ts
+++ b/src/content/docs/mmlClickEvent/index.ts
@@ -1,4 +1,4 @@
-import { DocsExamples } from "@/types/docs-reference";
+import { CLIENT_TYPES, DocsExamples } from "@/types/docs-reference";
 
 import clickedBy from "./clicked-by.mml";
 import position from "./position.mml";
@@ -14,7 +14,7 @@ export const examples: DocsExamples = {
     title: "Clicked by",
     description: "This example shows which client clicked the cube.",
     code: clickedBy,
-    clientsNumber: 2,
+    clients: [CLIENT_TYPES.FLOATING, CLIENT_TYPES.FLOATING],
     showClientsControls: true,
   },
   position: {

--- a/src/content/docs/mmlCollisionStartEvent/index.ts
+++ b/src/content/docs/mmlCollisionStartEvent/index.ts
@@ -1,3 +1,13 @@
-import { DocsExamples } from "@/types/docs-reference";
+import primary from "@/src/content/docs/mmlCollisionStartEvent/primary.mml";
+import { CLIENT_TYPES, DocsExamples } from "@/types/docs-reference";
 
-export const examples: DocsExamples = {};
+export const examples: DocsExamples = {
+  primary: {
+    title: "Collision start event",
+    description: "The label shows the connection id of the user colliding with the platform.",
+    code: primary,
+    clients: [CLIENT_TYPES.AVATAR, CLIENT_TYPES.AVATAR],
+    showClientsControls: true,
+    baseSceneOn: false,
+  },
+};

--- a/src/content/docs/mmlCollisionStartEvent/primary.mml
+++ b/src/content/docs/mmlCollisionStartEvent/primary.mml
@@ -1,0 +1,15 @@
+<m-label y="5" z="-3" width="10" height="5" color="red" font-size="150">
+</m-label>
+
+<m-cube id="my-cube" y="0.1" z="0" width="4" depth="2" height="0.3" collision-interval="100"></m-cube>
+
+<script>
+  const labelElement = document.querySelector("m-label")
+  const collidingCube = document.querySelector("#my-cube");
+
+  collidingCube.addEventListener("collisionstart", ({ detail }) => {
+    const text = `User ${detail.connectionId} has collided!`
+
+    labelElement.setAttribute("content", text)
+  })
+</script>

--- a/src/pages/docs/reference/elements/[reference-id].tsx
+++ b/src/pages/docs/reference/elements/[reference-id].tsx
@@ -12,6 +12,7 @@ import ExampleView from "@/src/components/ExampleView/DocsExampleViewDynamic";
 import { MarkDown } from "@/src/config/mdx";
 import * as docsExamples from "@/src/content/docs";
 import { getPageTitle } from "@/src/util";
+import { CLIENT_TYPES } from "@/types/docs-reference";
 
 // This function gets called at build time to generate all the files
 export function getStaticPaths() {
@@ -86,13 +87,13 @@ const DocsPage = ({ referenceId }: { referenceId: string }) => {
                 Try it
               </h2>
               <ExampleView
-                description="Demo"
+                description={primaryExample.description}
                 key={`${referenceId}-primary`}
                 baseScene={
                   primaryExample.baseSceneOn !== undefined ? primaryExample.baseSceneOn : true
                 }
                 code={primaryExample.code}
-                initialClientCount={1}
+                initialClients={primaryExample.clients ?? [CLIENT_TYPES.FLOATING]}
               />
             </>
           )}
@@ -141,7 +142,7 @@ const DocsPage = ({ referenceId }: { referenceId: string }) => {
                       description={example.title}
                       baseScene={example.baseSceneOn !== undefined ? example.baseSceneOn : true}
                       code={example.code}
-                      initialClientCount={1}
+                      initialClients={example.clients ?? [CLIENT_TYPES.FLOATING]}
                     />
                   </div>
                 );

--- a/src/pages/docs/reference/events/[event-id].tsx
+++ b/src/pages/docs/reference/events/[event-id].tsx
@@ -15,6 +15,7 @@ import { MarkDown } from "@/src/config/mdx";
 import * as docsExamples from "@/src/content/docs";
 import { getPageTitle } from "@/src/util";
 import { eventClasses } from "@/src/util/event-classes";
+import { CLIENT_TYPES } from "@/types/docs-reference";
 
 // This function gets called at build time to generate all the files
 export function getStaticPaths() {
@@ -115,13 +116,13 @@ const DocsPage = ({ eventId }: { eventId: string }) => {
                   Try it
                 </h2>
                 <ExampleView
-                  description="Demo"
+                  description={primaryExample.description}
                   key={`${eventId}-primary`}
                   baseScene={
                     primaryExample.baseSceneOn !== undefined ? primaryExample.baseSceneOn : true
                   }
                   code={primaryExample.code}
-                  initialClientCount={primaryExample?.clientsNumber ?? 1}
+                  initialClients={primaryExample.clients ?? [CLIENT_TYPES.FLOATING]}
                   showClientsControls={primaryExample?.showClientsControls}
                 />
               </>
@@ -186,7 +187,7 @@ const DocsPage = ({ eventId }: { eventId: string }) => {
                         description={example.title}
                         baseScene={example.baseSceneOn !== undefined ? example.baseSceneOn : true}
                         code={example.code}
-                        initialClientCount={example?.clientsNumber ?? 1}
+                        initialClients={example.clients ?? [CLIENT_TYPES.FLOATING]}
                         showClientsControls={example?.showClientsControls}
                       />
                     </div>

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -8,6 +8,7 @@ import { ChangeEvent, useEffect } from "react";
 import ExampleView from "@/src/components/ExampleView/ExamplePageExampleViewDynamic";
 import { examples } from "@/src/content/examples";
 import { getPageTitle } from "@/src/util";
+import { CLIENT_TYPES } from "@/types/docs-reference";
 import { Example, ExamplesByName } from "@/types/example";
 
 const ExamplesPage = () => {
@@ -109,7 +110,7 @@ const ExamplesPage = () => {
         <div className="h-full flex-1">
           <ExampleView
             key={selectedExample?.name || "default"}
-            initialClientCount={1}
+            initialClients={selectedExample?.clients ?? [CLIENT_TYPES.FLOATING]}
             code={selectedExample?.code || ""}
             baseScene={
               typeof selectedExample?.baseScene === "boolean" ? selectedExample?.baseScene : true

--- a/types/docs-reference.ts
+++ b/types/docs-reference.ts
@@ -1,9 +1,17 @@
+// Technically not a type but I'm not sure where to put this constant
+export const CLIENT_TYPES = {
+  FLOATING: "floating",
+  AVATAR: "avatar",
+} as const;
+
+export type ClientType = (typeof CLIENT_TYPES)[keyof typeof CLIENT_TYPES];
+
 export type DocsReference = {
   title: string;
   description: string;
   code: string;
   baseSceneOn?: boolean;
-  clientsNumber?: number;
+  clients?: ClientType[];
   showClientsControls?: boolean;
 };
 

--- a/types/example.ts
+++ b/types/example.ts
@@ -1,9 +1,12 @@
+import { ClientType } from "@/types/docs-reference";
+
 export type Example = {
   name: string;
   image: string;
   description: string;
   code: string;
   baseScene?: boolean;
+  clients?: ClientType[];
 };
 
 export type ExamplesByName = {


### PR DESCRIPTION
Handles #67 (though not all of it)

Modified the example view to show either the floating camera client or the avatar one
Updated examples and content for the new structure
Added basic example with avatar for mmlCollisionStart

**What kind of change does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [x] The title references the corresponding issue # (if relevant)

<img width="896" alt="image" src="https://github.com/mml-io/mml-website/assets/17921985/37b93873-e243-4870-bf20-46b4adad9e7c">
