### PR TITLE
Add m-interaction examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-markdown": "9.0.1",
+        "react-shadow": "20.5.0",
         "react-syntax-highlighter": "15.5.0",
         "remark-gfm": "4.0.0",
         "tailwind-merge": "2.3.0",
@@ -8649,6 +8650,11 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/humps": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
+      "integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g=="
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -29715,6 +29721,19 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-shadow": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/react-shadow/-/react-shadow-20.5.0.tgz",
+      "integrity": "sha512-DHukRfWpJrFtZMcZrKrqU3ZwuHjTpTbrjnJdTGZQE3lqtC5ivBDVWqAVVW6lR3Lq6bhphjAbqaJU8NOoTRSCsg==",
+      "dependencies": {
+        "humps": "^2.0.1"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-syntax-highlighter": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-markdown": "9.0.1",
+    "react-shadow": "20.5.0",
     "react-syntax-highlighter": "15.5.0",
     "remark-gfm": "4.0.0",
     "tailwind-merge": "2.3.0",

--- a/src/components/ExampleView/ExampleAvatarClient.tsx
+++ b/src/components/ExampleView/ExampleAvatarClient.tsx
@@ -19,6 +19,7 @@ export const ExampleAvatarClient = React.memo(function ExampleAvatarClient(props
 }) {
   const [client, setClient] = useState<LocalAvatarClient | null>(null);
   const elementRef = React.useRef<HTMLDivElement>(null);
+  const [loaded, setLoaded] = React.useState(false);
 
   useEffect(() => {
     let disposed = false;
@@ -47,15 +48,19 @@ export const ExampleAvatarClient = React.memo(function ExampleAvatarClient(props
   }, []);
 
   useEffect(() => {
-    if (elementRef.current && client) {
+    if (elementRef.current && client && loaded) {
       client.element.setAttribute("style", "height: 100%");
       elementRef.current.appendChild(client.element);
     }
-  }, [elementRef.current, client]);
+  }, [elementRef, client, loaded]);
 
   if (!client) {
     return null;
   }
 
-  return <ExampleClientView elementRef={elementRef}>{props.children}</ExampleClientView>;
+  return (
+    <ExampleClientView onLoad={() => setLoaded(true)} elementRef={elementRef}>
+      {props.children}
+    </ExampleClientView>
+  );
 });

--- a/src/components/ExampleView/ExampleClientView.tsx
+++ b/src/components/ExampleView/ExampleClientView.tsx
@@ -1,13 +1,35 @@
 import * as React from "react";
+import { useEffect } from "react";
+import ReactShadow from "react-shadow";
+
+// Use an element that will be loaded/rendered when the Shadow DOM is loaded to trigger the onLoad event.
+function OnLoadEl({ onLoad }: { onLoad: () => void }) {
+  useEffect(() => {
+    onLoad();
+  }, [onLoad]);
+  return <></>;
+}
 
 export default function ExampleClientView(props: {
   children?: React.ReactNode;
   elementRef: React.Ref<HTMLDivElement>;
+  onLoad: () => void;
 }) {
   const { children, elementRef } = props;
 
   return (
-    <div className="relative h-full min-h-0 w-full min-w-0" ref={elementRef}>
+    <div className="relative h-full min-h-0 w-full min-w-0">
+      <ReactShadow.div className="relative h-full min-h-0 w-full min-w-0">
+        <div
+          style={{
+            height: "100%",
+            width: "100%",
+            position: "relative",
+          }}
+          ref={elementRef}
+        ></div>
+        <OnLoadEl onLoad={props.onLoad} />
+      </ReactShadow.div>
       {children}
     </div>
   );

--- a/src/components/ExampleView/ExampleFloatingClient.tsx
+++ b/src/components/ExampleView/ExampleFloatingClient.tsx
@@ -20,6 +20,7 @@ export const ExampleFloatingClient = React.memo(function ExampleClient(props: {
     children?: React.ReactNode;
   } | null>(null);
   const elementRef = React.useRef<HTMLDivElement>(null);
+  const [loaded, setLoaded] = React.useState(false);
 
   useEffect(() => {
     let disposed = false;
@@ -62,10 +63,10 @@ export const ExampleFloatingClient = React.memo(function ExampleClient(props: {
   }, []);
 
   useEffect(() => {
-    if (elementRef.current && clientState) {
+    if (elementRef.current && clientState && loaded) {
       elementRef.current.appendChild(clientState.scene.element);
     }
-  }, [elementRef.current, clientState]);
+  }, [elementRef, clientState, loaded]);
 
   if (!clientState) {
     return null;
@@ -75,5 +76,9 @@ export const ExampleFloatingClient = React.memo(function ExampleClient(props: {
     clientState?.scene.fitContainer();
   }, 1);
 
-  return <ExampleClientView elementRef={elementRef}>{props.children}</ExampleClientView>;
+  return (
+    <ExampleClientView onLoad={() => setLoaded(true)} elementRef={elementRef}>
+      {props.children}
+    </ExampleClientView>
+  );
 });

--- a/src/content/docs/m-interaction/index.ts
+++ b/src/content/docs/m-interaction/index.ts
@@ -1,3 +1,18 @@
 import { DocsExamples } from "@/types/docs-reference";
 
-export const examples: DocsExamples = {};
+import multiple from "./multiple.mml";
+import primary from "./primary.mml";
+
+export const examples: DocsExamples = {
+  primary: {
+    title: "Basic m-interaction",
+    description: "This is a basic m-interaction.",
+    code: primary,
+  },
+  multiple: {
+    title: "Multiple m-interactions",
+    description:
+      "Multiple m-interactions can be present at once. The menu presents the available interactions. In this example the positions of the `m-interaction` elements differ to allow moving into range of multiple of the interactions or just a subset.",
+    code: multiple,
+  },
+};

--- a/src/content/docs/m-interaction/multiple.mml
+++ b/src/content/docs/m-interaction/multiple.mml
@@ -1,0 +1,20 @@
+<m-interaction x="-3" in-focus="false" prompt="Set to red" debug="true" id="red-interaction"></m-interaction>
+<m-interaction x="0" in-focus="false" prompt="Set to green" debug="true" id="green-interaction"></m-interaction>
+<m-interaction x="3" in-focus="false" prompt="Set to blue" debug="true" id="blue-interaction"></m-interaction>
+
+<m-cube y="1" id="color-cube" color="blue"></m-cube>
+
+<script>
+  const mCube = document.getElementById("color-cube");
+  document.getElementById("red-interaction").addEventListener("interact", () => {
+    mCube.setAttribute("color", "red");
+  });
+  document.getElementById("green-interaction").addEventListener("interact", () => {
+    mCube.setAttribute("color", "green");
+  });
+  document.getElementById("blue-interaction").addEventListener("interact", () => {
+    mCube.setAttribute("color", "blue");
+  });
+</script>
+
+<m-label id="my-label" y="7" width="10" height="2" content="Move into range and press E" font-size="80" alignment="center" color="#BBB" font-color="#000"></m-label>

--- a/src/content/docs/m-interaction/primary.mml
+++ b/src/content/docs/m-interaction/primary.mml
@@ -1,0 +1,22 @@
+<m-interaction
+    prompt="Toggle Color"
+    debug="true"
+    id="my-interaction"
+>
+  <m-cube y="1" id="color-cube" color="blue"></m-cube>
+</m-interaction>
+
+<script>
+  const mInteraction = document.getElementById("my-interaction");
+  const mCube = document.getElementById("color-cube");
+
+  let toggle = false;
+  function handleInteract() {
+    toggle = !toggle;
+    mCube.setAttribute("color", toggle ? "red" : "blue");
+  }
+
+  mInteraction.addEventListener("interact", handleInteract);
+</script>
+
+<m-label id="my-label" y="7" width="10" height="2" content="Move into range and press E" font-size="80" alignment="center" color="#BBB" font-color="#000"></m-label>


### PR DESCRIPTION
Re-attempt of #82 

* Adds examples for `m-interaction`
* Uses shadow DOM to isolate the styling for the interactive example clients to ensure buttons render correctly

**What kind of change does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR fulfill the following requirements?**

- [x] All tests are passing