### PR TITLE
adds proper link decoration for markdown content

### DIFF
--- a/src/pages/blog/[post-id].tsx
+++ b/src/pages/blog/[post-id].tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 import Head from "next/head";
 import Link from "next/link";
 import * as React from "react";
@@ -47,7 +48,7 @@ const GuidePage = ({ postId }: { postId: string }) => {
               <span>Back</span>
             </Link>
             <img src={image} alt={title} className="w-full" width="1024" height="530" />
-            <div className="mt-4">
+            <div className="mt-4 mdx">
               <Body />
             </div>
           </div>

--- a/src/pages/docs/guides/[guide-id].tsx
+++ b/src/pages/docs/guides/[guide-id].tsx
@@ -45,7 +45,7 @@ const GuidePage = ({ guideId }: { guideId: string }) => {
       <div className="flex pt-32">
         <ReferenceNavigation />
         <div className="px-5 sm:px-12 w-full">
-          <main className="mx-auto px-4 center-column">
+          <main className="mx-auto px-4 center-column mdx">
             <Breadcrumb
               pageName={title}
               parents={[

--- a/src/pages/docs/reference/elements/[reference-id].tsx
+++ b/src/pages/docs/reference/elements/[reference-id].tsx
@@ -68,7 +68,7 @@ const DocsPage = ({ referenceId }: { referenceId: string }) => {
       <div className="flex pt-32">
         <ReferenceNavigation />
         <div className="px-5 sm:px-12 w-full">
-          <main className="mx-auto px-4 center-column">
+          <main className="mx-auto px-4 center-column mdx">
             <Breadcrumb
               pageName={`${elementDefinition.name}`}
               parents={[

--- a/src/pages/docs/reference/events/[event-id].tsx
+++ b/src/pages/docs/reference/events/[event-id].tsx
@@ -101,7 +101,7 @@ const DocsPage = ({ eventId }: { eventId: string }) => {
       <div className="flex w-full pt-32">
         <ReferenceNavigation />
         <div className="px-5 sm:px-12 w-full">
-          <main className="mx-auto px-4 center-column">
+          <main className="mx-auto px-4 center-column mdx">
             <Breadcrumb
               pageName={`${eventClassDefinition.name}`}
               parents={[

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -41,3 +41,7 @@
     @apply opacity-100;
   }
 }
+
+code {
+  line-break: anywhere;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -12,6 +12,10 @@
   }
 }
 
+.mdx a {
+  text-decoration: underline;
+}
+
 @layer components {
   input[type="checkbox"]:checked ~ label span svg {
     @apply inline-flex;


### PR DESCRIPTION
This PR adds proper CSS styling for the links on the markdown content of the website (blog posts, guides, and reference content)

**What kind of change does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [X] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
